### PR TITLE
Add negative tabindex to skip focusing empty links in browsers

### DIFF
--- a/templates/_indieweb.html
+++ b/templates/_indieweb.html
@@ -2,11 +2,11 @@
     send that as the primary tag, and any tags on the entry itself will also be sent out as well. -#}
 {%- for crumb in category.breadcrumb|reverse %}
 {%- if crumb.tag %}
-<a class="u-syndication" href="https://indieweb.xyz/en/{{crumb.tag|urlencode}}"></a>
+<a class="u-syndication" href="https://indieweb.xyz/en/{{crumb.tag|urlencode}}" tabindex="-1"></a>
 {%- endif %}
 {%- endfor %}
 {%- for tag in entry.tags %}
-<a class="u-syndication" href="https://indieweb.xyz/en/{{tag|urlencode}}"></a>
+<a class="u-syndication" href="https://indieweb.xyz/en/{{tag|urlencode}}" tabindex="-1"></a>
 {%- endfor %}
 
 {#- support the common webmention ping types by setting appropriate entry headers, like:
@@ -48,7 +48,7 @@
 -#}
 {%- for ping in entry.get_all('ping') -%}
     {%- with link, class = ping.split() -%}
-        <a href="{{link}}" class="hidden {{class}}"></a>
+        <a href="{{link}}" class="hidden {{class}}" tabindex="-1"></a>
     {%- endwith -%}
 {%- endfor -%}
 


### PR DESCRIPTION
There are a couple of `<a>` elements sprinkled throughout that lack context and even link text. I noticed this when I had to tab through every tag on an article twice before focus ended up inside the article. (I did not even realise the second time was tabbing through indieweb.xyz links!)

Especially in _indieweb.html they seem to be all about providing extra machine-readable metadata. This PR simply takes them out of the tabbing order completely.

I think the better fix for machine-readable data is to move away from using `<a>` entirely. Those elements should be limited to offering people navigational paths, not metadata for computers. The latter is often better off in `<link>`. But because I wasn’t a 100% sure on the purpose of the specific elements here, or what the parsers support, I left them as-is.